### PR TITLE
Enhanced metadata

### DIFF
--- a/src/GeekLearning.Storage.Azure/Internal/AzureFileReference.cs
+++ b/src/GeekLearning.Storage.Azure/Internal/AzureFileReference.cs
@@ -11,6 +11,12 @@
     {
         private ICloudBlob cloudBlob;
 
+        public AzureFileReference(string path, ICloudBlob cloudBlob)
+        {
+            this.Path = path;
+            this.cloudBlob = cloudBlob;
+        }
+
         public AzureFileReference(IListBlobItem blobItem)
            : this(blobItem as ICloudBlob)
         {
@@ -21,17 +27,12 @@
         {
         }
 
-        public AzureFileReference(string path, ICloudBlob cloudBlob)
-        {
-            this.Path = path;
-            this.cloudBlob = cloudBlob;
-        }
-
         public AzureFileReference(ICloudBlob cloudBlob) :
             this(cloudBlob.Name, cloudBlob)
         {
-
         }
+
+        public string Path { get; }
 
         public DateTimeOffset? LastModified => this.cloudBlob.Properties?.LastModified;
 
@@ -39,7 +40,7 @@
 
         public long? Length => this.cloudBlob.Properties?.Length;
 
-        public string Path { get; }
+        public string ETag => this.cloudBlob.Properties?.ETag;
 
         public string PublicUrl => cloudBlob.Uri.ToString();
 

--- a/src/GeekLearning.Storage.FileSystem/FileSystemStore.cs
+++ b/src/GeekLearning.Storage.FileSystem/FileSystemStore.cs
@@ -33,23 +33,6 @@
 
         public string Name { get; }
 
-        private Internal.FileSystemFileReference InternalGetAsync(IPrivateFileReference file)
-        {
-            var reference = InternalGetOrCreateAsync(file);
-            if (File.Exists(reference.FileSystemPath))
-            {
-                return reference;
-            }
-
-            return null;
-        }
-
-        private Internal.FileSystemFileReference InternalGetOrCreateAsync(IPrivateFileReference file)
-        {
-            var fullPath = Path.Combine(this.absolutePath, file.Path);
-            return new Internal.FileSystemFileReference(fullPath, file.Path, this.Name, this.publicUrlProvider);
-        }
-
         public Task<IFileReference> GetAsync(IPrivateFileReference file, bool withMetadata)
         {
             IFileReference fileReference = this.InternalGetAsync(file);
@@ -138,6 +121,11 @@
             return Task.FromResult((IFileReference)fileReference);
         }
 
+        public Task<IFileReference> AddMetadataAsync(IPrivateFileReference file, IDictionary<string, string> metadata)
+        {
+            throw new NotImplementedException();
+        }
+
         private void EnsurePathExists(string path)
         {
             var directoryPath = Path.GetDirectoryName(path);
@@ -147,9 +135,21 @@
             }
         }
 
-        public Task<IFileReference> AddMetadataAsync(IPrivateFileReference file, IDictionary<string, string> metadata)
+        private Internal.FileSystemFileReference InternalGetAsync(IPrivateFileReference file)
         {
-            throw new NotImplementedException();
+            var reference = InternalGetOrCreateAsync(file);
+            if (File.Exists(reference.FileSystemPath))
+            {
+                return reference;
+            }
+
+            return null;
+        }
+
+        private Internal.FileSystemFileReference InternalGetOrCreateAsync(IPrivateFileReference file)
+        {
+            var fullPath = Path.Combine(this.absolutePath, file.Path);
+            return new Internal.FileSystemFileReference(fullPath, file.Path, this.Name, this.publicUrlProvider);
         }
     }
 }

--- a/src/GeekLearning.Storage.FileSystem/Internal/FileSystemFileReference.cs
+++ b/src/GeekLearning.Storage.FileSystem/Internal/FileSystemFileReference.cs
@@ -7,8 +7,6 @@
 
     public class FileSystemFileReference : IFileReference
     {
-        private string filePath;
-        private string path;
         private IPublicUrlProvider publicUrlProvider;
         private string storeName;
         private FileInfo fileInfo;
@@ -17,12 +15,14 @@
         {
             this.storeName = storeName;
             this.publicUrlProvider = publicUrlProvider;
-            this.filePath = filePath;
-            this.path = path.Replace('\\', '/');
+            this.FileSystemPath = filePath;
+            this.Path = path.Replace('\\', '/');
             this.fileInfo = new FileInfo(this.FileSystemPath);
         }
 
-        public string FileSystemPath => this.filePath;
+        public string FileSystemPath { get; }
+
+        public string Path { get; }
 
         public IDictionary<string, string> Metadata
         {
@@ -32,8 +32,13 @@
             }
         }
 
-        public string Path => this.path;
-
+        public string ETag
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         public string PublicUrl
         {
@@ -62,7 +67,7 @@
 
         public Task DeleteAsync()
         {
-            File.Delete(this.filePath);
+            File.Delete(this.FileSystemPath);
             return Task.FromResult(true);
         }
 
@@ -83,13 +88,13 @@
 
         public Task<Stream> ReadAsync()
         {
-            Stream stream = File.OpenRead(this.filePath);
+            Stream stream = File.OpenRead(this.FileSystemPath);
             return Task.FromResult(stream);
         }
 
         public async Task ReadToStreamAsync(Stream targetStream)
         {
-            using (var file = File.Open(this.filePath, FileMode.Open, FileAccess.Read))
+            using (var file = File.Open(this.FileSystemPath, FileMode.Open, FileAccess.Read))
             {
                 await file.CopyToAsync(targetStream);
             }
@@ -97,7 +102,7 @@
 
         public async Task UpdateAsync(Stream stream)
         {
-            using (var file = File.Open(this.filePath, FileMode.Truncate, FileAccess.Write))
+            using (var file = File.Open(this.FileSystemPath, FileMode.Truncate, FileAccess.Write))
             {
                 await stream.CopyToAsync(file);
             }

--- a/src/GeekLearning.Storage/IFileReference.cs
+++ b/src/GeekLearning.Storage/IFileReference.cs
@@ -15,6 +15,8 @@
 
         long? Length { get; }
 
+        string ETag { get; }
+
         IDictionary<string, string> Metadata { get; }
 
         Task ReadToStreamAsync(Stream targetStream);


### PR DESCRIPTION
# Issues

- Fix #19: expose file's etags
- Fix #16: store content type with metadata with the FileSystem provider

# Breaking changes

- No more automatic FetchProperties for the Azure Provider: it is now dependent of the `withMetadata` parameter
- All the properties and metadata are now exposed on a `IFileReference` via a `IFileProperties` instance. For example, you should now access the Length like this: `file.Properties.Length`
- There is no more `AddMetadata` method on `IStore` or on `IFileReference`. You should now modify metadata on the `IFileProperties` directly, and then call the method `SavePropertiesAsync`